### PR TITLE
MOEN-44496: Update Android native dependencies and add new APIs

### DIFF
--- a/Android/RichNotification/Assets/RichNotification/Editor/RichNotificationDependencies.xml
+++ b/Android/RichNotification/Assets/RichNotification/Editor/RichNotificationDependencies.xml
@@ -2,7 +2,7 @@
 <dependencies>
 
   <androidPackages>
-    <androidPackage spec="com.moengage:rich-notification:4.7.2">
+    <androidPackage spec="com.moengage:rich-notification:6.6.0">
     </androidPackage>
   </androidPackages>
 

--- a/Android/android-unity-wrapper/gradle/libs.versions.toml
+++ b/Android/android-unity-wrapper/gradle/libs.versions.toml
@@ -1,6 +1,10 @@
 [libraries]
-appCompat = { group = "androidx.appcompat", name = "appcompat", version = "1.6.1" }
-core = { group = "com.moengage", name = "moe-android-sdk", version = "12.10.02" }
-inapp = { group = "com.moengage", name = "inapp", version = "7.1.1" }
-basePlugin = { group = "com.moengage", name = "plugin-base", version = "3.4.1" }
-basePluginGeofence = { group = "com.moengage", name = "plugin-base-geofence", version = "1.2.0" }
+androidXCompact = { group = "androidx.appcompat", name = "appcompat", version = "1.7.0" }
+androidXCore = { group = "androidx.core", name = "core", version = "1.15.0"}
+androidXLifecycle = { group = "androidx.lifecycle", name = "lifecycle-process", version = "2.8.7"}
+geofence = { module = "com.moengage:geofence" }
+moengageAndroidBom = { module = "com.moengage:android-bom", version = "2.2.3" }
+moengageInapp = { module = "com.moengage:inapp" }
+moengagePluginBaseBom = { module = "com.moengage:plugin-base-bom", version = "3.0.1" }
+moengagePluginBase = { module = "com.moengage:plugin-base" }
+moengagePluginBaseGeofence = { module = "com.moengage:plugin-base-geofence" }

--- a/Android/android-unity-wrapper/gradle/wrapper/gradle-wrapper.properties
+++ b/Android/android-unity-wrapper/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Apr 24 10:25:45 IST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/Android/android-unity-wrapper/publishing-plugin/build.gradle.kts
+++ b/Android/android-unity-wrapper/publishing-plugin/build.gradle.kts
@@ -12,7 +12,6 @@
  */
 
 plugins {
-    kotlin("jvm") version "1.5.10"
     `kotlin-dsl`
 }
 
@@ -23,4 +22,18 @@ repositories {
 
 dependencies {
     implementation(kotlin("stdlib"))
+}
+
+// Pin the JVM target explicitly. Without this, the `kotlin-dsl` plugin derives the
+// target from the JDK running Gradle (e.g. JDK 21), which the bundled Kotlin compiler
+// does not recognise ("Unknown Kotlin JVM target: 21").
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+    kotlinOptions {
+        jvmTarget = "17"
+    }
 }

--- a/Android/android-unity-wrapper/scripts/common.gradle
+++ b/Android/android-unity-wrapper/scripts/common.gradle
@@ -16,10 +16,10 @@ apply plugin: "kotlin-android"
 
 android {
 
-  compileSdk = 33
+  compileSdk = 36
   defaultConfig {
-    minSdk = 21
-    targetSdk = 33
+    minSdk = 23
+    targetSdk = 36
   }
 
   compileOptions {

--- a/Android/android-unity-wrapper/settings.gradle.kts
+++ b/Android/android-unity-wrapper/settings.gradle.kts
@@ -30,7 +30,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("moengageInternal") {
-            from("com.moengage:android-dependency-catalog-internal:2.0.0")
+            from("com.moengage:android-dependency-catalog-internal:3.1.0")
         }
     }
 }

--- a/Android/android-unity-wrapper/unity-wrapper-geofence/build.gradle.kts
+++ b/Android/android-unity-wrapper/unity-wrapper-geofence/build.gradle.kts
@@ -34,7 +34,10 @@ android {
 }
 
 dependencies {
-    compileOnly(libs.core)
-    api(libs.basePluginGeofence)
+    compileOnly(moengageInternal.kotlinStdLib)
+    implementation(platform(libs.moengageAndroidBom))
+    compileOnly(libs.geofence)
+    implementation(platform(libs.moengagePluginBaseBom))
+    implementation(libs.moengagePluginBaseGeofence)
     compileOnly(project(":unity-wrapper"))
 }

--- a/Android/android-unity-wrapper/unity-wrapper-geofence/gradle.properties
+++ b/Android/android-unity-wrapper/unity-wrapper-geofence/gradle.properties
@@ -13,4 +13,4 @@
 ARTIFACT_NAME=unity-wrapper-geofence
 NAME=MoEngage Geofence Unity Wrapper
 DESCRIPTION=Module for MoEngage geofence unity wrapper
-VERSION_NAME=1.1.0
+VERSION_NAME=1.2.0

--- a/Android/android-unity-wrapper/unity-wrapper/build.gradle.kts
+++ b/Android/android-unity-wrapper/unity-wrapper/build.gradle.kts
@@ -38,9 +38,16 @@ android {
 dependencies {
     compileOnly(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar"))))
     implementation(moengageInternal.kotlinStdLib)
-    compileOnly(libs.appCompat)
-    compileOnly(libs.core)
-    compileOnly(libs.inapp)
-    api(libs.basePlugin)
+
+    api(libs.androidXCompact)
+    api(libs.androidXCore)
+    api(libs.androidXLifecycle)
+
+    implementation(platform(libs.moengageAndroidBom))
+    compileOnly(libs.moengageInapp)
+
+    implementation(platform(libs.moengagePluginBaseBom))
+    implementation(libs.moengagePluginBase)
+
     compileOnly(project(":unity-library"))
 }

--- a/Android/android-unity-wrapper/unity-wrapper/gradle.properties
+++ b/Android/android-unity-wrapper/unity-wrapper/gradle.properties
@@ -13,4 +13,4 @@
 ARTIFACT_NAME=unity-wrapper
 NAME=MoEngage Unity Wrapper
 DESCRIPTION=Wrapper SDK for unity framework support on MoEngage Platform
-VERSION_NAME=3.2.0
+VERSION_NAME=3.3.0

--- a/Android/android-unity-wrapper/unity-wrapper/src/main/java/com/moengage/unity/wrapper/Constants.kt
+++ b/Android/android-unity-wrapper/unity-wrapper/src/main/java/com/moengage/unity/wrapper/Constants.kt
@@ -38,5 +38,10 @@ internal const val METHOD_NAME_IN_APP_CUSTOM_ACTION = "InAppCampaignCustomAction
 internal const val METHOD_NAME_IN_APP_SELF_HANDLED = "InAppCampaignSelfHandled"
 internal const val METHOD_NAME_PUSH_TOKEN = "PushToken"
 internal const val METHOD_NAME_PERMISSION_RESULT = "onPermissionResult"
+internal const val METHOD_NAME_USER_IDENTITIES = "UserIdentitiesCallback"
+internal const val METHOD_NAME_SELF_HANDLED_INAPPS = "InAppSelfHandledCampaignsCallback"
+internal const val METHOD_NAME_LOGOUT_COMPLETE = "LogoutComplete"
 
 internal const val ARGUMENT_IS_SUCCESS = "isSuccess"
+
+internal const val INTEGRATION_TYPE = "unity"

--- a/Android/android-unity-wrapper/unity-wrapper/src/main/java/com/moengage/unity/wrapper/EventEmitterImpl.kt
+++ b/Android/android-unity-wrapper/unity-wrapper/src/main/java/com/moengage/unity/wrapper/EventEmitterImpl.kt
@@ -30,8 +30,10 @@ import com.moengage.core.internal.logger.Logger
 import com.moengage.plugin.base.internal.EventEmitter
 import com.moengage.plugin.base.internal.clickDataToJson
 import com.moengage.plugin.base.internal.inAppDataToJson
+import com.moengage.plugin.base.internal.logoutCompleteEventToJson
 import com.moengage.plugin.base.internal.model.events.Event
 import com.moengage.plugin.base.internal.model.events.EventType
+import com.moengage.plugin.base.internal.model.events.LogoutCompleteEvent
 import com.moengage.plugin.base.internal.model.events.inapp.InAppActionEvent
 import com.moengage.plugin.base.internal.model.events.inapp.InAppLifecycleEvent
 import com.moengage.plugin.base.internal.model.events.inapp.InAppSelfHandledEvent
@@ -65,6 +67,7 @@ internal class EventEmitterImpl(private val gameObjectName: String) : EventEmitt
         eventMap[EventType.INAPP_SELF_HANDLED_AVAILABLE] = METHOD_NAME_IN_APP_SELF_HANDLED
         eventMap[EventType.PUSH_TOKEN_GENERATED] = METHOD_NAME_PUSH_TOKEN
         eventMap[EventType.PERMISSION] = METHOD_NAME_PERMISSION_RESULT
+        eventMap[EventType.LOGOUT_COMPLETE] = METHOD_NAME_LOGOUT_COMPLETE
     }
 
     override fun emit(event: Event) {
@@ -77,6 +80,7 @@ internal class EventEmitterImpl(private val gameObjectName: String) : EventEmitt
                 is InAppLifecycleEvent -> emitInAppLifecycleEvent(event)
                 is InAppSelfHandledEvent -> emitInAppSelfHandledEvent(event)
                 is PermissionEvent -> emitPermissionEvent(event)
+                is LogoutCompleteEvent -> emitLogoutCompleteEvent(event)
 
             }
         } catch (t: Throwable) {
@@ -134,7 +138,8 @@ internal class EventEmitterImpl(private val gameObjectName: String) : EventEmitt
         try {
             Logger.print { "$tag emitInAppSelfHandledEvent(): inAppSelfHandledEvent=${inAppSelfHandledEvent.eventType}, selfHandledData=${inAppSelfHandledEvent.data}" }
             val methodName = eventMap[inAppSelfHandledEvent.eventType] ?: return
-            val inAppSelfHandledEventPayload = selfHandledDataToJson(inAppSelfHandledEvent.data)
+            val inAppSelfHandledEventPayload =
+                selfHandledDataToJson(inAppSelfHandledEvent.accountMeta, inAppSelfHandledEvent.data)
             emit(methodName, inAppSelfHandledEventPayload)
         } catch (t: Throwable) {
             Logger.print(LogLevel.ERROR, t) { "$tag emitInAppSelfHandledEvent() : " }
@@ -149,6 +154,17 @@ internal class EventEmitterImpl(private val gameObjectName: String) : EventEmitt
             emit(methodName, permissionPayload)
         } catch (t: Throwable) {
             Logger.print(LogLevel.ERROR, t) { "$tag emitPermissionEvent() : " }
+        }
+    }
+
+    private fun emitLogoutCompleteEvent(logoutCompleteEvent: LogoutCompleteEvent) {
+        try {
+            Logger.print { "$tag emitLogoutCompleteEvent(): logoutCompleteEvent=$logoutCompleteEvent" }
+            val methodName = eventMap[logoutCompleteEvent.eventType] ?: return
+            val payload = logoutCompleteEventToJson(logoutCompleteEvent)
+            emit(methodName, payload)
+        } catch (t: Throwable) {
+            Logger.print(LogLevel.ERROR, t) { "$tag emitLogoutCompleteEvent() : " }
         }
     }
 

--- a/Android/android-unity-wrapper/unity-wrapper/src/main/java/com/moengage/unity/wrapper/MoEAndroidWrapper.kt
+++ b/Android/android-unity-wrapper/unity-wrapper/src/main/java/com/moengage/unity/wrapper/MoEAndroidWrapper.kt
@@ -3,14 +3,13 @@ package com.moengage.unity.wrapper
 import android.content.Context
 import com.moengage.core.LogLevel
 import com.moengage.core.internal.logger.Logger
-import com.moengage.core.internal.model.IntegrationMeta
 import com.moengage.plugin.base.internal.ARGUMENT_DATA
 import com.moengage.plugin.base.internal.PluginHelper
-import com.moengage.plugin.base.internal.PluginInitializer
-import com.moengage.plugin.base.internal.instanceMetaFromJson
+import com.moengage.plugin.base.internal.selfHandledInAppsToJson
 import com.moengage.plugin.base.internal.setEventEmitter
 import com.moengage.unity.wrapper.internal.PayloadTransformer
 import com.moengage.unity.wrapper.internal.UserDeletionCallback
+import com.unity3d.player.UnityPlayer
 import org.json.JSONObject
 
 /**
@@ -28,6 +27,7 @@ public class MoEAndroidWrapper private constructor() {
 
     private val tag = "${MODULE_TAG}MoEAndroidWrapper"
     private var context: Context? = null
+    private var gameObjectName: String? = null
 
     public companion object {
 
@@ -59,6 +59,7 @@ public class MoEAndroidWrapper private constructor() {
                 ) { "$tag initialize() : Game object name is empty cannot pass callbacks" }
                 return
             }
+            this.gameObjectName = gameObjectName
             setEventEmitter(EventEmitterImpl(gameObjectName))
             pluginHelper.initialise(initializationJson)
         } catch (t: Throwable) {
@@ -283,4 +284,76 @@ public class MoEAndroidWrapper private constructor() {
             Logger.print(LogLevel.ERROR, t) { "$tag deleteUser(): " }
         }
     }
+
+    public fun showNudge(nudgePayload: String) {
+        try {
+            Logger.print { "$tag showNudge() : Will try to show nudge, payload: $nudgePayload" }
+            pluginHelper.showNudge(getContext(), nudgePayload)
+        } catch (t: Throwable) {
+            Logger.print(LogLevel.ERROR, t) { "$tag showNudge() : " }
+        }
+    }
+
+    public fun getSelfHandledInApps(accountPayload: String) {
+        try {
+            Logger.print { "$tag getSelfHandledInApps() : Will try to fetch self-handled in-apps" }
+            pluginHelper.getSelfHandledInApps(getContext(), accountPayload) { data ->
+                sendCallback(
+                    METHOD_NAME_SELF_HANDLED_INAPPS,
+                    selfHandledInAppsToJson(data).toString()
+                )
+            }
+        } catch (t: Throwable) {
+            Logger.print(LogLevel.ERROR, t) { "$tag getSelfHandledInApps() : " }
+        }
+    }
+
+    public fun identifyUser(identifyPayload: String) {
+        try {
+            Logger.print { "$tag identifyUser() : Identify Payload: $identifyPayload" }
+            pluginHelper.identifyUser(getContext(), identifyPayload)
+        } catch (t: Throwable) {
+            Logger.print(LogLevel.ERROR, t) { "$tag identifyUser() : " }
+        }
+    }
+
+    public fun getUserIdentities(accountPayload: String) {
+        try {
+            Logger.print { "$tag getUserIdentities() : Account Payload: $accountPayload" }
+            pluginHelper.getUserIdentities(getContext(), accountPayload) { identities ->
+                val payload = if (identities == null) {
+                    JSONObject()
+                } else {
+                    JSONObject(identities)
+                }
+                sendCallback(METHOD_NAME_USER_IDENTITIES, payload.toString())
+            }
+        } catch (t: Throwable) {
+            Logger.print(LogLevel.ERROR, t) { "$tag getUserIdentities() : " }
+        }
+    }
+
+
+    /**
+     * Forwards an asynchronous result to the Unity layer via [UnityPlayer.UnitySendMessage].
+     *
+     * @param methodName the receiving method on the Unity game object.
+     * @param payload JSON string payload.
+     */
+    private fun sendCallback(methodName: String, payload: String) {
+        try {
+            val gameObject = gameObjectName
+            if (gameObject.isNullOrEmpty()) {
+                Logger.print(LogLevel.ERROR) {
+                    "$tag sendCallback() : Game object name is empty, cannot send $methodName"
+                }
+                return
+            }
+            Logger.print { "$tag sendCallback() : methodName=$methodName, payload=$payload" }
+            UnityPlayer.UnitySendMessage(gameObject, methodName, payload)
+        } catch (t: Throwable) {
+            Logger.print(LogLevel.ERROR, t) { "$tag sendCallback() : " }
+        }
+    }
+
 }

--- a/Android/android-unity-wrapper/unity-wrapper/src/main/java/com/moengage/unity/wrapper/MoEInitializer.kt
+++ b/Android/android-unity-wrapper/unity-wrapper/src/main/java/com/moengage/unity/wrapper/MoEInitializer.kt
@@ -25,10 +25,12 @@
  */
 package com.moengage.unity.wrapper
 
+import android.app.Application
 import android.content.Context
 import com.moengage.core.LogLevel
 import com.moengage.core.MoEngage
 import com.moengage.core.internal.logger.Logger
+import com.moengage.core.internal.model.IntegrationMeta
 import com.moengage.core.model.SdkState
 import com.moengage.plugin.base.internal.PluginInitializer
 
@@ -49,12 +51,13 @@ public object MoEInitializer {
      */
     public fun initialiseDefaultInstance(context: Context, builder: MoEngage.Builder) {
         try {
-            Logger.print { "$tag initialiseDefaultInstance(): : Will try to initialise the sdk" }
-            Logger.print { "$tag initialiseDefaultInstance(): : unity wrapper version: ${BuildConfig.MOENGAGE_ANDROID_UNITY_WRAPPER}" }
             MoEAndroidWrapper.getInstance().setContext(context)
             PluginInitializer.initialize(
-                builder
+                builder,
+                IntegrationMeta(INTEGRATION_TYPE, BuildConfig.MOENGAGE_ANDROID_UNITY_WRAPPER)
             )
+            Logger.print { "$tag initialiseDefaultInstance(): initialised the sdk" }
+            Logger.print { "$tag initialiseDefaultInstance(): unity wrapper version: ${BuildConfig.MOENGAGE_ANDROID_UNITY_WRAPPER}" }
         } catch (t: Throwable) {
             Logger.print(LogLevel.ERROR, t) { "$tag initialiseDefaultInstance(): " }
         }
@@ -74,16 +77,43 @@ public object MoEInitializer {
         sdkState: SdkState
     ) {
         try {
-            Logger.print { "$tag initialiseDefaultInstance(): : Will try to initialise the sdk" }
-            Logger.print { "$tag initialiseDefaultInstance(): : unity wrapper version: ${BuildConfig.MOENGAGE_ANDROID_UNITY_WRAPPER}" }
             MoEAndroidWrapper.getInstance().setContext(context)
             PluginInitializer.initialize(
                 builder = builder,
-                integrationMeta = null,
+                integrationMeta = IntegrationMeta(INTEGRATION_TYPE, BuildConfig.MOENGAGE_ANDROID_UNITY_WRAPPER),
                 sdkState = sdkState
             )
+            Logger.print { "$tag initialiseDefaultInstance(): initialised the sdk" }
+            Logger.print { "$tag initialiseDefaultInstance(): unity wrapper version: ${BuildConfig.MOENGAGE_ANDROID_UNITY_WRAPPER}" }
         } catch (t: Throwable) {
             Logger.print(LogLevel.ERROR, t) { "$tag initialiseDefaultInstance(): " }
+        }
+    }
+
+    /**
+     * Initialize SDK using file based configuration.
+     *
+     * Note: While using this function to intialize the SDK, make sure you have configured all the
+     * required configuration in the xml as resource value
+     */
+    public fun initialiseDefaultInstance(
+        application: Application,
+        sdkState: SdkState? = null,
+    ) {
+        try {
+            MoEAndroidWrapper.getInstance().setContext(application.applicationContext)
+            PluginInitializer.initialize(
+                application = application,
+                integrationMeta = IntegrationMeta(
+                    INTEGRATION_TYPE,
+                    BuildConfig.MOENGAGE_ANDROID_UNITY_WRAPPER
+                ),
+                sdkState = sdkState
+            )
+            Logger.print { "$tag initialize(): initialised the sdk via file" }
+            Logger.print { "$tag initialiseDefaultInstance(): unity wrapper version: ${BuildConfig.MOENGAGE_ANDROID_UNITY_WRAPPER}" }
+        } catch (t: Throwable) {
+            Logger.print(LogLevel.ERROR, t) { "$tag initialize(): " }
         }
     }
 }

--- a/Cards/Assets/Cards/Editor/CardsDependencies.xml
+++ b/Cards/Assets/Cards/Editor/CardsDependencies.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <dependencies>
     <androidPackages>
-        <androidPackage spec="com.moengage:cards-ui:1.6.1"/>
+        <androidPackage spec="com.moengage:cards-ui:3.5.0"/>
     </androidPackages>
     
     <iosPods>

--- a/Core-SDK/Assets/MoEngage/Editor/MoEngageDependencies.xml
+++ b/Core-SDK/Assets/MoEngage/Editor/MoEngageDependencies.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <dependencies>
   <androidPackages>
-    <androidPackage spec="com.moengage:moe-android-sdk:12.10.02"/>
-    <androidPackage spec="com.moengage:unity-wrapper:3.2.0"/>
+    <androidPackage spec="com.moengage:moe-android-sdk:14.09.01"/>
+    <androidPackage spec="com.moengage:unity-wrapper:3.3.0"/>
   </androidPackages>
     
   <!-- iOS Cocoapod dependencies can be specified by each iosPod element. -->

--- a/Core-SDK/Assets/MoEngage/Scripts/Internal/MoEngageAndroid.cs
+++ b/Core-SDK/Assets/MoEngage/Scripts/Internal/MoEngageAndroid.cs
@@ -17,9 +17,10 @@ using System.Collections.Generic;
 using UnityEngine;
 using MoEMiniJSON;
 
-namespace MoEngage {
+namespace MoEngage
+{
 
-  #if UNITY_ANDROID
+#if UNITY_ANDROID
   public class MoEngageAndroid: MoEngageUnityPlatform {
     
     private const string TAG = "MoEngageAndroid";
@@ -31,27 +32,27 @@ namespace MoEngage {
     /// </summary>
     /// <param name="gameObject"></param>
     public void Initialize(string gameObjectPayload) {
-      #if!UNITY_EDITOR
+#if !UNITY_EDITOR
       moengageAndroid.Call("initialize", gameObjectPayload);
-      #endif
+#endif
     }
 
     public void SetAppStatus(string appStatusPayload) {
-      #if!UNITY_EDITOR
+#if !UNITY_EDITOR
       moengageAndroid.Call("setAppStatus", appStatusPayload);
-      #endif
+#endif
     }
 
     public void SetAlias(string aliasPayload) {
-      #if!UNITY_EDITOR
+#if !UNITY_EDITOR
       moengageAndroid.Call("setAlias", aliasPayload);
-      #endif
+#endif
     }
 
     public void SetUserAttribute(string userAttributesPayload) {
-      #if!UNITY_EDITOR
+#if !UNITY_EDITOR
       moengageAndroid.Call("setUserAttribute", userAttributesPayload);
-      #endif
+#endif
     }
 
     /// <summary>
@@ -60,144 +61,170 @@ namespace MoEngage {
     /// <param name="eventName"></param>
     /// <param name="attributes"></param>
     public void TrackEvent(string eventPayload) {
-      #if!UNITY_EDITOR
+#if !UNITY_EDITOR
       moengageAndroid.Call("trackEvent", eventPayload);
-      #endif
+#endif
     }
 
     public void Logout(string accountPayload) {
-      #if!UNITY_EDITOR
+#if !UNITY_EDITOR
       moengageAndroid.Call("logout", accountPayload);
-      #endif
+#endif
     }
 
     public void GetSelfHandledInApp(string accountPayload) {
-      #if!UNITY_EDITOR
+#if !UNITY_EDITOR
       Debug.Log(TAG + ": GetSelfHandledInApp::");
       moengageAndroid.Call("getSelfHandledInApp", accountPayload);
-      #endif
+#endif
     }
 
     public void ShowInApp(string accountPayload) {
-      #if!UNITY_EDITOR
+#if !UNITY_EDITOR
       Debug.Log(TAG + ": ShowInApp::");
       moengageAndroid.Call("showInApp", accountPayload);
-      #endif
+#endif
     }
 
     public static void PassFcmPushPayload(string pushPayload) {
-      #if!UNITY_EDITOR
+#if !UNITY_EDITOR
       Debug.Log(TAG + ": PassFcmPushPayload:: pushPayload: " + pushPayload);
       moengageAndroid.Call("passPushPayload", pushPayload);
-      #endif
+#endif
     }
 
     public static void PassFcmPushToken(string pushTokenPayload) {
-      #if!UNITY_EDITOR
+#if !UNITY_EDITOR
       Debug.Log(TAG + ": PassFcmPushToken:: pushToken: " + pushTokenPayload);
       moengageAndroid.Call("passPushToken", pushTokenPayload);
-      #endif
+#endif
     }
 
     public void SelfHandledShown(string selfHandledPayload) {
-      #if!UNITY_EDITOR
+#if !UNITY_EDITOR
       moengageAndroid.Call("selfHandledCallback", selfHandledPayload);
-      #endif
+#endif
     }
 
     public void SelfHandledClicked(string selfHandledPayload) {
-      #if!UNITY_EDITOR
+#if !UNITY_EDITOR
       moengageAndroid.Call("selfHandledCallback", selfHandledPayload);
-      #endif
+#endif
     }
 
     public void SelfHandledDismissed(string selfHandledPayload) {
-      #if!UNITY_EDITOR
+#if !UNITY_EDITOR
       moengageAndroid.Call("selfHandledCallback", selfHandledPayload);
-      #endif
+#endif
     }
 
     public void SetInAppContexts(string contextPayload) {
-      #if!UNITY_EDITOR
+#if !UNITY_EDITOR
       moengageAndroid.Call("setAppContext", contextPayload);
-      #endif
+#endif
     }
 
     public void ResetInAppContexts(string accountPayload) {
-      #if!UNITY_EDITOR
+#if !UNITY_EDITOR
       Debug.Log(TAG + " resetInAppContexts:: ");
       moengageAndroid.Call("resetContext", accountPayload);
-      #endif
+#endif
     }
 
     public void optOutDataTracking(string optOutPayload) {
-      #if!UNITY_EDITOR
+#if !UNITY_EDITOR
       moengageAndroid.Call("optOutTracking", optOutPayload);
-      #endif
+#endif
     }
 
     public void UpdateSdkState(string payload) {
-      #if!UNITY_EDITOR
+#if !UNITY_EDITOR
       moengageAndroid.Call("updateSdkState", payload);
-      #endif
+#endif
     }
 
     public static void OnOrientationChanged() {
-      #if!UNITY_EDITOR
+#if !UNITY_EDITOR
       Debug.Log(TAG + " OnOrientationChanged::");
       moengageAndroid.Call("onOrientationChanged");
-      #endif
+#endif
     }
 
     public static void SetupNotificationChannelsAndroid() {
-      #if!UNITY_EDITOR
+#if !UNITY_EDITOR
       Debug.Log(TAG + " SetupNotificationChannelsAndroid::");
       moengageAndroid.Call("setUpNotificationChannels");
-      #endif
+#endif
     }
 
     public static void PushPermissionResponseAndroid(string payload) {
-      #if!UNITY_EDITOR
+#if !UNITY_EDITOR
       Debug.Log(TAG + " PushPermissionResponseAndroid:: payload: " + payload);
       moengageAndroid.Call("permissionResponse", payload);
-      #endif
+#endif
     }
 
     public static void NavigateToSettingsAndroid() {
-      #if!UNITY_EDITOR
+#if !UNITY_EDITOR
       Debug.Log(TAG + " NavigateToSettingsAndroid:: ");
       moengageAndroid.Call("navigateToSettings");
-      #endif
+#endif
     }
 
     public static void RequestPushPermissionAndroid() {
-      #if!UNITY_EDITOR
+#if !UNITY_EDITOR
       Debug.Log(TAG + " RequestPushPermissionAndroid:: ");
       moengageAndroid.Call("requestPushPermission");
-      #endif
+#endif
     }
 
     public static void UpdatePushPermissionRequestCountAndroid(string payload) {
-      #if!UNITY_EDITOR
+#if !UNITY_EDITOR
       Debug.Log(TAG + " UpdatePushPermissionRequestCountAndroid:: payload: " + payload);
       moengageAndroid.Call("updatePushPermissionRequestCount", payload);
-      #endif
+#endif
     }
 
     public static void UpdateDeviceIdentifierTrackingStatus(string payload) {
-      #if!UNITY_EDITOR
+#if !UNITY_EDITOR
       Debug.Log(TAG + " UpdateDeviceIdentifierTrackingStatus:: payload: " + payload);
       moengageAndroid.Call("deviceIdentifierTrackingStatusUpdate", payload);
-      #endif
+#endif
     }
 
     public static void DeleteUser(string accountPayload, UserDeletionResponseDelegate delegateFunc) {
-      #if!UNITY_EDITOR
+#if !UNITY_EDITOR
       Debug.Log(TAG + " DeleteUser:: accountPayload: " + accountPayload);
       moengageAndroid.Call("deleteUser", new UserDeletionCallback(delegateFunc), accountPayload);
-      #endif
+#endif
+    }
+
+    public void IdentifyUser(string identifyPayload) {
+#if !UNITY_EDITOR
+      moengageAndroid.Call("identifyUser", identifyPayload);
+#endif
+    }
+
+    public void GetUserIdentities(string accountPayload) {
+#if !UNITY_EDITOR
+      moengageAndroid.Call("getUserIdentities", accountPayload);
+#endif
+    }
+
+    public void ShowNudge(string nudgePayload) {
+#if !UNITY_EDITOR
+      Debug.Log(TAG + ": ShowNudge::");
+      moengageAndroid.Call("showNudge", nudgePayload);
+#endif
+    }
+
+    public void GetSelfHandledInApps(string accountPayload) {
+#if !UNITY_EDITOR
+      Debug.Log(TAG + ": GetSelfHandledInApps::");
+      moengageAndroid.Call("getSelfHandledInApps", accountPayload);
+#endif
     }
   }
 
-  #endif
+#endif
 }

--- a/Geofence/Assets/Geofence/Editor/GeofenceDependencies.xml
+++ b/Geofence/Assets/Geofence/Editor/GeofenceDependencies.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <dependencies>
   <androidPackages>
-    <androidPackage spec="com.moengage:geofence:3.4.0"/>
-    <androidPackage spec="com.moengage:unity-wrapper-geofence:1.1.0"/>
+    <androidPackage spec="com.moengage:geofence:5.4.0"/>
+    <androidPackage spec="com.moengage:unity-wrapper-geofence:1.2.0"/>
   </androidPackages>
   <!-- iOS Cocoapod dependencies can be specified by each iosPod element. -->
   <iosPods>

--- a/InApps/Assets/InApps/Editor/InAppsDependencies.xml
+++ b/InApps/Assets/InApps/Editor/InAppsDependencies.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <dependencies>
     <androidPackages>
-        <androidPackage spec="com.moengage:inapp:7.1.2"/>
+        <androidPackage spec="com.moengage:inapp:10.2.0"/>
     </androidPackages>
 </dependencies>

--- a/changelogs/moengage.md
+++ b/changelogs/moengage.md
@@ -11,6 +11,8 @@
 - Added support for displaying non-intrusive nudge campaigns
 - Added support for fetching multiple self-handled In-App messages simultaneously using the `GetSelfHandledInApps()` method.
 - Added support for session-triggered InApps and support multiple screen names in DisplayRules.
+- Android
+  - Migrated Android native dependencies to MoEngage BOMs (`android-bom` 2.2.3)
 - iOS
   - Added suport for Swift Package manager. 
   - Updated MoEngage-iOS-SDK to 10.12.0


### PR DESCRIPTION
- Migrate Android native dependencies to MoEngage BOMs (android-bom 2.2.3, plugin-base-bom 3.0.1) and bump SDK specs (moe-android-sdk 14.09.01, inapp 10.2.0, cards-ui 3.5.0, geofence 5.4.0, rich-notification 6.6.0)
- Bump unity-wrapper to 3.3.0 and unity-wrapper-geofence to 1.2.0
- Raise compileSdk/targetSdk to 36, minSdk to 23; Gradle 8.13; pin publishing-plugin JVM target to 17
- Add nudge, multi self-handled in-app, identifyUser, getUserIdentities, logout-complete callback, and file-based initialization support
- Pass IntegrationMeta (unity) on initialization